### PR TITLE
Add "gribmagic unity list" subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,12 @@ make test
 
 ### Ad hoc usage
 ```
+# List available labels.
+gribmagic unity list
+
+# Acquire data.
 export GM_DATA_PATH=.gribmagic-data
-gribmagic unity --model=dwd-icon-eu --timestamp=2021-10-03T00:00:00Z
+gribmagic unity acquire --model=dwd-icon-eu --timestamp=2021-10-03T00:00:00Z
 ```
 
 ### Configuration
@@ -96,7 +100,7 @@ docker build --tag gribmagic .
 
 and then invoke it like
 ```
-docker run -it --volume=$PWD/.gribmagic-data:/var/spool/gribmagic gribmagic:latest gribmagic unity --model=dwd-icon-eu --timestamp=2021-10-03T00:00:00Z
+docker run -it --volume=$PWD/.gribmagic-data:/var/spool/gribmagic gribmagic:latest gribmagic unity acquire --model=dwd-icon-eu --timestamp=2021-10-03T00:00:00Z
 ```
 
 ---

--- a/gribmagic/commands.py
+++ b/gribmagic/commands.py
@@ -1,4 +1,5 @@
 """Command line entry points for NWP data download"""
+import json
 import logging
 from datetime import datetime
 from typing import Union
@@ -7,6 +8,7 @@ import click
 
 from gribmagic.unity.core import run_model_download
 from gribmagic.unity.enumerations.weather_models import WeatherModels
+from gribmagic.unity.modules.config.parse_configurations import parse_model_config
 from gribmagic.util import setup_logging
 
 logger = logging.getLogger(__name__)
@@ -20,14 +22,27 @@ setup_logging()
 
 @click.group()
 @click.pass_context
-def main(ctx):
+def cli(ctx):
     pass
 
 
-@main.command()
+@cli.group(help="Unified NWP data downloader")
+@click.pass_context
+def unity(ctx):
+    pass
+
+
+@unity.command(name="list", help="List available NWP data labels")
+def unity_list():
+    model_config = parse_model_config()
+    labels = [label for label in model_config.keys() if not label.endswith("-base")]
+    print(json.dumps(labels, indent=4))
+
+
+@unity.command(name="acquire", help="Acquire NWP data")
 @click.option("--model", required=True, help="The weather model name.")
 @click.option("--timestamp", required=True, help="The initialization timestamp.")
-def unity(model: Union[str, WeatherModels], timestamp: Union[str, datetime]):
+def unity_acquire(model: Union[str, WeatherModels], timestamp: Union[str, datetime]):
     logger.info("Starting GribMagic")
     results = run_model_download(
         weather_model=model, initialization_timestamp=timestamp

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(name='gribmagic',
       },
       entry_points={
         'console_scripts': [
-          'gribmagic = gribmagic.commands:main',
+          'gribmagic = gribmagic.commands:cli',
         ],
       },
 )


### PR DESCRIPTION
Invoking `gribmagic unity list` will list the available models, like
```
[
    "ncep-gfs-025",
    "ncep-gfs-050",
    "ncep-gfs-100",
    "dwd-icon-global",
    "dwd-icon-eu",
    "dwd-icon-eu-eps",
    "dwd-cosmo-d2",
    "dwd-cosmo-d2-eps",
    "meteo-france-arome",
    "knmi-harmonie"
]
```
