### PR TITLE
Adds command line parameter "--target"

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,5 +1,8 @@
-This is a list of the people who directly contributed to
-GribMagic in one way or another, in the order of appearance.
+This is an alphabetically-ordered list of the people who contributed to
+GribMagic in one way or another.
 
-* Daniel Lassahn <daniel.lassahn@meteointelligence.de>
 * Andreas Motl <andreas.motl@panodata.org>
+* Benjamin Gutzmann <gutzemann@gmail.com>
+* Daniel Lassahn <daniel.lassahn@meteointelligence.de>
+* Matthias Mehldau <matthias.mehldau@panodata.org>
+* Michael Haberler <mah@mah.priv.at>

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ test-coverage: testdata-download testoutput-clean
 		--cov-report=xml
 
 format:
-	$(pip) install --requirement=requirements-dev.txt --quiet
-	$(isort) --profile=black gribmagic tests
-	$(black) gribmagic tests
+	@$(pip) install --requirement=requirements-dev.txt --quiet
+	@$(isort) --profile=black gribmagic tests
+	@$(black) gribmagic tests
 
 install-magics:
 	mkdir -p tmp/download tmp/build/magics

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ make test
 
 ### Ad hoc usage
 ```
-# List available labels.
+# List labels of available models.
 gribmagic unity list
 
 # Acquire data.
@@ -91,7 +91,7 @@ ECCODES_DEFINITION_PATH=/usr/share/eccodes/definitions:/usr/local/opt/eccodes/sh
 
 ## Run program in Docker
 
-To use gribmagic in a Docker container, you have to build the Docker image like
+To use GribMagic in a Docker container, you have to build the Docker image like
 ```
 docker build --tag gribmagic .
 ```

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ make test
 gribmagic unity list
 
 # Acquire data.
-export GM_DATA_PATH=.gribmagic-data
-gribmagic unity acquire --model=dwd-icon-eu --timestamp=2021-10-03T00:00:00Z
+gribmagic unity acquire --model=dwd-icon-eu --timestamp=2021-10-03T00:00:00Z --target=.gribmagic-data
 ```
 
 ### Configuration
@@ -88,7 +87,6 @@ GM_MODEL_VARIABLES_LEVELS_MAPPING={PATH_TO_PROJECT}/config/model_variables_level
 
 ECCODES_DEFINITION_PATH=/usr/share/eccodes/definitions:/usr/local/opt/eccodes/share/eccodes/definitions
 ```
-The **GM_DATA_PATH** points to the project intern **data** directory per default. 
 
 
 ## Run program in Docker

--- a/demo/publishing/wms_server.py
+++ b/demo/publishing/wms_server.py
@@ -6,7 +6,7 @@ import sys
 # of ``skinnywms.wmssvr`` on the global module scope.
 # Will have to send a pull request to get things straight.
 #
-# So, maybe better use ``skinny-wms --path=$GM_DATA_PATH/tmp``.
+# So, maybe better use ``skinny-wms --path=.gribmagic-data/raw``.
 
 
 def wms_server(filepath=None):

--- a/docs/backlog.rst
+++ b/docs/backlog.rst
@@ -1,5 +1,5 @@
 #################
-gribmagic backlog
+GribMagic backlog
 #################
 
 
@@ -11,12 +11,13 @@ Prio 1
 - [x] Add demo program for selecting area of interest based on bounding box
 - [x] Inline default mapping YAML files into package
 - [x] Improve test coverage and reactivate Codecov uploads
-- [o] Code refactoring
 - [x] Get rid of ``tmp`` subdirectory
 - [x] Get rid of ``remote_server_type``
 - [x] Flip "Product » Provider" to "Provider » Product"
 - [x] Run ``isort`` and ``black``
-- [o] Optionally obtain target directory (``GM_DATA_PATH``) from command line parameter
+- [x] Obtain target directory from command line parameter
+- [o] Maybe use model name as subdirectory for storing data
+- [o] Large code refactoring
 - [o] Improve README
 - [o] Improve sandbox (just type ``make test``)
 - [o] CI: Add test matrix for Python 3.7, 3.8 and 3.9
@@ -45,10 +46,19 @@ Prio 2
 - [o] Improve documentation
     - https://www.nco.ncep.noaa.gov/pmb/products/gfs/
     - http://dcpc-nwp.meteo.fr/
+    - https://www.emc.ncep.noaa.gov/emc/pages/numerical_forecast_systems/gefs.php
     - https://en.wikipedia.org/wiki/National_Centers_for_Environmental_Prediction
+    - https://gsl.noaa.gov/focus-areas/unified_forecast_system
+    - https://vlab.noaa.gov/web/environmental-modeling-center/unified-forecast-system
+    - https://ufscommunity.org/
+    - https://ufscommunity.org/about/what-is-ufs/
+    - https://ufscommunity.org/news/srwa/
 
 - [o] Complete products
     - AROME has more grid resolutions
+
+- [o] Add more models
+    - https://de.wikipedia.org/wiki/Numerische_Wettervorhersage#Modelle
 
 
 ******

--- a/docs/publishing/dap.rst
+++ b/docs/publishing/dap.rst
@@ -61,10 +61,10 @@ ECMWF's `ecCodes software`_ ships appropriate tools,
 specifically grib_to_netcdf_. See also `How to convert GRIB to netCDF`_.
 ::
 
-    export GM_DATA_PATH=.gribmagic-data
+    export DATA_PATH=.gribmagic-data
     grib_to_netcdf -k 4 \
-        -o ${GM_DATA_PATH}/netcdf/icon_eu_20201220_00_air_temperature_2m_000.nc \
-        ${GM_DATA_PATH}/tmp/icon_eu_20201220_00_air_temperature_2m_000.grib2
+        -o ${DATA_PATH}/netcdf/icon_eu_20201220_00_air_temperature_2m_000.nc \
+        ${DATA_PATH}/raw/icon_eu_20201220_00_air_temperature_2m_000.grib2
 
 .. _ecCodes software: https://confluence.ecmwf.int/display/ECC
 .. _How to convert GRIB to netCDF: https://confluence.ecmwf.int/display/OIFS/How+to+convert+GRIB+to+netCDF
@@ -77,13 +77,13 @@ In this example, we are using the `Hyrax Docker`_ distribution.
 
 Run::
 
-    export GM_DATA_PATH=.gribmagic-data
+    export DATA_PATH=.gribmagic-data
 
     docker run \
         --rm --interactive --tty \
         --publish 4000:8080 \
         --env NCWMS_BASE=http://localhost:4000 \
-        --volume $(pwd)/${GM_DATA_PATH}/netcdf:/usr/share/hyrax \
+        --volume $(pwd)/${DATA_PATH}/netcdf:/usr/share/hyrax \
         opendap/hyrax:latest
 
     open http://localhost:4000/
@@ -95,8 +95,8 @@ Server (Pydap)
 ==============
 ::
 
-    export GM_DATA_PATH=.gribmagic-data
-    pydap --data=${GM_DATA_PATH}/netcdf --port=4000
+    export DATA_PATH=.gribmagic-data
+    pydap --data=${DATA_PATH}/netcdf --port=4000
 
 
 Client (Xarray)

--- a/docs/publishing/wms.rst
+++ b/docs/publishing/wms.rst
@@ -50,8 +50,7 @@ Server
 ::
 
     export MAGPLUS_HOME=/usr/local/opt/magics
-    export GM_DATA_PATH=.gribmagic-data
-    skinny-wms --path=$GM_DATA_PATH/tmp
+    skinny-wms --path=.gribmagic-data/raw
     open http://localhost:5000/
 
 

--- a/docs/publishing/xpublish.rst
+++ b/docs/publishing/xpublish.rst
@@ -35,8 +35,7 @@ Server
 ======
 ::
 
-    export GM_DATA_PATH=.gribmagic-data
-    python demo/publishing/xpublish_server.py $GM_DATA_PATH/tmp/icon_eu_20201220_00_air_temperature_2m_000.grib2
+    python demo/publishing/xpublish_server.py .gribmagic-data/icon_eu_20201220_00_air_temperature_2m_000.grib2
     open http://localhost:9000/
 
 

--- a/gribmagic/commands.py
+++ b/gribmagic/commands.py
@@ -2,6 +2,7 @@
 import json
 import logging
 from datetime import datetime
+from pathlib import Path
 from typing import Union
 
 import click
@@ -42,10 +43,17 @@ def unity_list():
 @unity.command(name="acquire", help="Acquire NWP data")
 @click.option("--model", required=True, help="The weather model name.")
 @click.option("--timestamp", required=True, help="The initialization timestamp.")
-def unity_acquire(model: Union[str, WeatherModels], timestamp: Union[str, datetime]):
+@click.option(
+    "--target", required=True, envvar="GM_DATA_PATH", help="The target directory."
+)
+def unity_acquire(
+    model: Union[str, WeatherModels],
+    timestamp: Union[str, datetime],
+    target: Union[str, Path],
+):
     logger.info("Starting GribMagic")
     results = run_model_download(
-        weather_model=model, initialization_timestamp=timestamp
+        weather_model=model, initialization_timestamp=timestamp, target_directory=target
     )
 
     # If a func call raises an exception, then that exception will be raised

--- a/gribmagic/unity/core.py
+++ b/gribmagic/unity/core.py
@@ -1,8 +1,10 @@
 """ pre defined pipelines for download """
 from datetime import datetime
+from pathlib import Path
 from typing import Union
 
 from gribmagic.unity.enumerations.weather_models import WeatherModels
+from gribmagic.unity.models import AcquisitionRecipe
 from gribmagic.unity.modules.download.download import download
 from gribmagic.unity.modules.file_list_handling.file_list_handling import (
     build_model_file_lists,
@@ -13,20 +15,18 @@ from gribmagic.unity.modules.time.time_parsing import convert_iso_timestamp_to_d
 def run_model_download(
     weather_model: Union[str, WeatherModels],
     initialization_timestamp: Union[str, datetime],
+    target_directory: Union[str, Path],
 ) -> None:
     """
     Run a full stack model download as defined in `model_config.yml`.
 
     Args:
-        weather_model: is one of
-            - dwd-icon-global, dwd-icon-eu, dwd-icon-eu-eps
-            - dwd-cosmo-d2, dwd-cosmo-d2-eps
-            - ncep-gfs-025, meteo-france-arome, knmi-harmonie
-        initialization_timestamp:
-            - nwp run initialization time
+        :param weather_model: One of `WeatherModels`.
+        :param initialization_timestamp: NWP run initialization time.
+        :param target_directory: Where to store data into.
 
     Returns:
-        Stores data on file system defined by environment variable "GM_DATA_PATH"
+        Download weather forecast data and store into filesystem.
     """
 
     weather_model = WeatherModels(weather_model)
@@ -35,7 +35,9 @@ def run_model_download(
         initialization_timestamp = convert_iso_timestamp_to_date_time(
             initialization_timestamp
         )
-    model_file_list = build_model_file_lists(
-        weather_model, initialization_timestamp.hour, initialization_timestamp.date()
+
+    recipe = AcquisitionRecipe(
+        model=weather_model, timestamp=initialization_timestamp, target=target_directory
     )
+    model_file_list = build_model_file_lists(recipe)
     return download(weather_model, model_file_list, parallel_download=True)

--- a/gribmagic/unity/models/__init__.py
+++ b/gribmagic/unity/models/__init__.py
@@ -1,4 +1,7 @@
+import dataclasses
 import logging
+from datetime import datetime
+from pathlib import Path
 
 from cachetools import cachedmethod
 
@@ -14,6 +17,33 @@ from gribmagic.unity.modules.config.constants import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class AcquisitionRecipe:
+
+    # Define the weather model.
+    model: WeatherModels
+
+    # Timestamp of forecast run.
+    timestamp: datetime
+
+    # Destination directory.
+    target: Path
+
+    @property
+    def run_date(self) -> datetime.date:
+        """
+        Date when forecast started.
+        """
+        return self.timestamp.date()
+
+    @property
+    def run_hour(self) -> int:
+        """
+        Time of the day when forecast started.
+        """
+        return self.timestamp.hour
 
 
 class WeatherModelSettings:

--- a/gribmagic/unity/modules/download/download.py
+++ b/gribmagic/unity/modules/download/download.py
@@ -34,7 +34,7 @@ def download(
     n_processes: int = DEFAULT_NUMBER_OF_PARALLEL_PROCESSES,
 ) -> None:
     """
-    download weather forecasts
+    Download weather forecasts data.
     """
 
     model = WeatherModelSettings(weather_model)

--- a/gribmagic/unity/modules/file_list_handling/file_list_handling.py
+++ b/gribmagic/unity/modules/file_list_handling/file_list_handling.py
@@ -1,9 +1,8 @@
-""" functions to create remote lists of remote files that should be downloaded """
-from datetime import datetime
+""" Create lists of remote and local files """
 from pathlib import Path
 from typing import Dict, List, Union
 
-from gribmagic.unity.enumerations.weather_models import WeatherModels
+from gribmagic.unity.models import AcquisitionRecipe
 from gribmagic.unity.modules.config.constants import (
     KEY_LOCAL_FILE_PATHS,
     KEY_LOCAL_STORE_FILE_PATHS,
@@ -19,31 +18,21 @@ from gribmagic.unity.modules.file_list_handling.remote_file_list_creation import
 
 
 def build_model_file_lists(
-    weather_model: WeatherModels, initialization_time: int, run_date: datetime.date
+    recipe: AcquisitionRecipe,
 ) -> Dict[str, List[Union[str, Path]]]:
     """
-    builds a Dictionary with local and remote file paths for the given model
-
-    Args:
-        weather_model: defines the weather model
-        initialization_time: time of the day when forecast started
-        run_date: date when forecast started
+    Build a dictionary with local and remote file paths for the given model.
 
     Returns:
-        Dict with lists for
+        Dictionary with lists for
             - local storing
             - intermediate local store
             - remote file path for downloading
 
     """
+
     return {
-        KEY_LOCAL_STORE_FILE_PATHS: build_local_store_file_list_for_variables(
-            weather_model, initialization_time, run_date
-        ),
-        KEY_LOCAL_FILE_PATHS: build_local_file_list(
-            weather_model, initialization_time, run_date
-        ),
-        KEY_REMOTE_FILE_PATHS: build_remote_file_list(
-            weather_model, initialization_time, run_date
-        ),
+        KEY_LOCAL_STORE_FILE_PATHS: build_local_store_file_list_for_variables(recipe),
+        KEY_LOCAL_FILE_PATHS: build_local_file_list(recipe),
+        KEY_REMOTE_FILE_PATHS: build_remote_file_list(recipe),
     }

--- a/gribmagic/unity/modules/file_list_handling/local_file_list_creation.py
+++ b/gribmagic/unity/modules/file_list_handling/local_file_list_creation.py
@@ -1,11 +1,9 @@
-""" functions to create remote lists of remote files that should be downloaded """
-import os
-from datetime import datetime
+""" Create lists of files to download into local filesystem """
 from pathlib import Path
 from typing import Dict, List
 
 from gribmagic.unity.enumerations.weather_models import WeatherModels
-from gribmagic.unity.models import WeatherModelSettings
+from gribmagic.unity.models import AcquisitionRecipe, WeatherModelSettings
 from gribmagic.unity.modules.config.constants import (
     KEY_FILE_POSTFIX,
     KEY_FORECAST_STEPS,
@@ -15,84 +13,64 @@ from gribmagic.unity.modules.config.constants import (
 )
 
 
-def build_local_store_file_list_for_variables(
-    weather_model: WeatherModels, initialization_time: int, run_date: datetime.date
-) -> List[Path]:
+def build_local_store_file_list_for_variables(recipe: AcquisitionRecipe) -> List[Path]:
     """
-    Generic file path generator for persisting local netcdf files
-
-    Args:
-        weather_model: defines the weather model
-        initialization_time: time of the day when forecast started
-        run_date: date when forecast started
+    Generic file path generator for persisting local netCDF files.
 
     Returns:
         List of local store file paths
 
     """
-    model = WeatherModelSettings(weather_model)
-    data_path = Path(os.environ["GM_DATA_PATH"])
+    model = WeatherModelSettings(recipe.model)
     local_file_list = []
     for variable in model.variables:
         local_file_list.append(
             Path(
-                data_path,
-                weather_model.value,
-                f"{run_date.strftime('%Y%m%d')}_{str(initialization_time).zfill(2)}",
+                recipe.target,
+                recipe.model.value,
+                f"{recipe.run_date.strftime('%Y%m%d')}_{str(recipe.run_hour).zfill(2)}",
                 f"{variable}.{LOCAL_FILE_POSTFIX}",
             )
         )
     return local_file_list
 
 
-def build_local_file_list(
-    weather_model: WeatherModels,
-    initialization_time: int,
-    run_date: datetime.date,
-) -> List[Path]:
+def build_local_file_list(recipe: AcquisitionRecipe) -> List[Path]:
     """
-    Generic file path generator downloaded grib data per each variable
-
-    Args:
-        weather_model: defines the weather model
-        initialization_time: time of the day when forecast started
-        run_date: date when forecast started
+    Generic file path generator for downloaded GRIB data per each variable.
 
     Returns:
         List of temporary locally stored files
 
     """
-    model = WeatherModelSettings(weather_model)
+    model = WeatherModelSettings(recipe.model)
 
-    if weather_model == WeatherModels.KNMI_HARMONIE:
-        return _local_file_paths_for_harmonie(run_date, initialization_time, model.info)
+    if recipe.model == WeatherModels.KNMI_HARMONIE:
+        return _local_file_paths_for_harmonie(recipe, model.info)
     elif model.has_grib_packages:
         variables_iterator = model.info[KEY_GRIB_PACKAGE_TYPES]
     else:
         variables_iterator = model.variables
 
     return _build_local_file_list_with_variables_iterator(
-        weather_model, run_date, initialization_time, variables_iterator, model.info
+        recipe, variables_iterator, model.info
     )
 
 
 def _build_local_file_list_with_variables_iterator(
-    weather_model: WeatherModels,
-    run_date: datetime,
-    initialization_time: int,
+    recipe: AcquisitionRecipe,
     variables_iterator: List[str],
     model_config,
 ) -> List[Path]:
-    data_path = Path(os.environ["GM_DATA_PATH"])
     local_file_list = []
     for var in variables_iterator:
         if "{forecast_step}" in model_config[KEY_URL_FILE]:
-            for forecast_step in model_config[KEY_FORECAST_STEPS][initialization_time]:
+            for forecast_step in model_config[KEY_FORECAST_STEPS][recipe.run_hour]:
                 local_file_list.append(
                     Path(
-                        data_path,
-                        f"{weather_model.value}_{run_date.strftime('%Y%m%d')}_"
-                        f"{str(initialization_time).zfill(2)}_{var}_"
+                        recipe.target,
+                        f"{recipe.model.value}_{recipe.run_date.strftime('%Y%m%d')}_"
+                        f"{str(recipe.run_hour).zfill(2)}_{var}_"
                         f"{str(forecast_step).zfill(3)}.{model_config[KEY_FILE_POSTFIX]}",
                     )
                 )
@@ -101,9 +79,9 @@ def _build_local_file_list_with_variables_iterator(
             # However, raw files are only available via API these days.
             local_file_list.append(
                 Path(
-                    data_path,
-                    f"{weather_model.value}_{run_date.strftime('%Y%m%d')}_"
-                    f"{str(initialization_time).zfill(2)}_{var}."
+                    recipe.target,
+                    f"{recipe.model.value}_{recipe.run_date.strftime('%Y%m%d')}_"
+                    f"{str(recipe.run_hour).zfill(2)}_{var}."
                     f"{model_config[KEY_FILE_POSTFIX]}",
                 )
             )
@@ -111,26 +89,18 @@ def _build_local_file_list_with_variables_iterator(
 
 
 def _local_file_paths_for_harmonie(
-    run_date: datetime, initialization_time: int, model_config: Dict[str, any]
+    recipe: AcquisitionRecipe, model_config: Dict[str, any]
 ) -> List[Path]:
     """
-    special local file path generator for HARMONIE model
-    Args:
-        run_date:
-        initialization_time:
-        model_config:
-
-    Returns:
-
+    Local file path generator for HARMONIE model.
     """
-    data_path = Path(os.environ["GM_DATA_PATH"])
     local_file_list = []
-    for forecast_step in model_config[KEY_FORECAST_STEPS][initialization_time]:
+    for forecast_step in model_config[KEY_FORECAST_STEPS][recipe.run_hour]:
         local_file_list.append(
             Path(
-                data_path,
-                f"{WeatherModels.KNMI_HARMONIE.value}_{run_date.strftime('%Y%m%d')}_"
-                f"{str(initialization_time).zfill(2)}_{forecast_step}."
+                recipe.target,
+                f"{WeatherModels.KNMI_HARMONIE.value}_{recipe.run_date.strftime('%Y%m%d')}_"
+                f"{str(recipe.run_hour).zfill(2)}_{forecast_step}."
                 f"{model_config[KEY_FILE_POSTFIX]}",
             )
         )

--- a/tests/unity/conftest.py
+++ b/tests/unity/conftest.py
@@ -1,3 +1,0 @@
-import os
-
-os.environ["GM_DATA_PATH"] = "/app/data"

--- a/tests/unity/file_list_handling/test_file_list_handling.py
+++ b/tests/unity/file_list_handling/test_file_list_handling.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,6 +14,7 @@ from gribmagic.unity.modules.config.constants import (
 from gribmagic.unity.modules.file_list_handling.file_list_handling import (
     build_model_file_lists,
 )
+from tests.unity.fixtures import recipe_icon
 
 
 @patch(
@@ -33,9 +33,7 @@ from gribmagic.unity.modules.file_list_handling.file_list_handling import (
     },
 )
 def test_build_model_file_lists():
-    to_test = build_model_file_lists(
-        WeatherModels.DWD_ICON_EU, 0, datetime(2020, 6, 10).date()
-    )
+    to_test = build_model_file_lists(recipe_icon)
     assert to_test == {
         "local_file_paths": [
             Path("/app/data/dwd-icon-eu_20200610_00_air_temperature_2m_000.grib"),

--- a/tests/unity/file_list_handling/test_local_file_list_creation.py
+++ b/tests/unity/file_list_handling/test_local_file_list_creation.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,6 +14,7 @@ from gribmagic.unity.modules.file_list_handling.local_file_list_creation import 
     build_local_file_list,
     build_local_store_file_list_for_variables,
 )
+from tests.unity.fixtures import recipe_arome, recipe_harmonie, recipe_icon
 
 
 @patch(
@@ -30,9 +30,7 @@ from gribmagic.unity.modules.file_list_handling.local_file_list_creation import 
     },
 )
 def test_build_local_file_list_for_variables():
-    to_test = build_local_file_list(
-        WeatherModels.DWD_ICON_EU, 0, datetime(2020, 6, 10).date()
-    )
+    to_test = build_local_file_list(recipe_icon)
     assert to_test == [
         Path("/app/data/dwd-icon-eu_20200610_00_air_temperature_2m_000.grib"),
         Path("/app/data/dwd-icon-eu_20200610_00_air_temperature_2m_001.grib"),
@@ -52,9 +50,7 @@ def test_build_local_file_list_for_variables():
     },
 )
 def test_build_local_store_file_list_for_variables():
-    to_test = build_local_store_file_list_for_variables(
-        WeatherModels.DWD_ICON_EU, 0, datetime(2020, 6, 10).date()
-    )
+    to_test = build_local_store_file_list_for_variables(recipe_icon)
     assert to_test == [Path("/app/data/dwd-icon-eu/20200610_00/air_temperature_2m.nc")]
 
 
@@ -72,9 +68,7 @@ def test_build_local_store_file_list_for_variables():
     },
 )
 def test_build_local_file_list_for_variables_grib_package():
-    to_test = build_local_file_list(
-        WeatherModels.METEO_FRANCE_AROME, 0, datetime(2020, 6, 10).date()
-    )
+    to_test = build_local_file_list(recipe_arome)
     assert to_test == [
         Path("/app/data/meteo-france-arome_20200610_00_Package1_000.grib"),
         Path("/app/data/meteo-france-arome_20200610_00_Package1_001.grib"),
@@ -94,9 +88,7 @@ def test_build_local_file_list_for_variables_grib_package():
     },
 )
 def test_build_local_file_list_for_harmonie():
-    to_test = build_local_file_list(
-        WeatherModels.KNMI_HARMONIE, 0, datetime(2020, 6, 10).date()
-    )
+    to_test = build_local_file_list(recipe_harmonie)
     assert to_test == [
         Path("/app/data/knmi-harmonie_20200610_00_0.grib"),
         Path("/app/data/knmi-harmonie_20200610_00_1.grib"),
@@ -105,8 +97,7 @@ def test_build_local_file_list_for_harmonie():
 
 def test_local_file_paths_for_harmonie():
     to_test = _local_file_paths_for_harmonie(
-        datetime(2020, 6, 10).date(),
-        0,
+        recipe_harmonie,
         {
             KEY_URL_FILE: "harm40_{grib_package_type}_{initialization_time}.tar",
             KEY_VARIABLES: ["air_temperature_2m"],

--- a/tests/unity/file_list_handling/test_remote_file_list_creation.py
+++ b/tests/unity/file_list_handling/test_remote_file_list_creation.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -22,6 +21,7 @@ from gribmagic.unity.modules.file_list_handling.remote_file_list_creation import
     remote_files_grib_directories,
     remote_files_grib_packages,
 )
+from tests.unity.fixtures import recipe_arome, recipe_icon
 
 
 @patch(
@@ -39,9 +39,7 @@ from gribmagic.unity.modules.file_list_handling.remote_file_list_creation import
     },
 )
 def test_build_remote_model_file_lists():
-    to_test = remote_files_grib_directories(
-        WeatherModels.DWD_ICON_EU, 0, datetime(2020, 6, 10).date()
-    )
+    to_test = remote_files_grib_directories(recipe_icon)
     assert to_test == [
         "http://foobar.example.org/test_remote_dir/00/t_2m/test_remote_file_single-level_2020061000_000_T_2M.grib2.bz2",
         "http://foobar.example.org/test_remote_dir/00/t_2m/test_remote_file_single-level_2020061000_001_T_2M.grib2.bz2",
@@ -50,9 +48,7 @@ def test_build_remote_model_file_lists():
 
 def test_build_remote_model_file_lists_wrong_weather_model():
     with pytest.raises(WrongWeatherModelException) as exc:
-        _ = remote_files_grib_directories(
-            WeatherModels.METEO_FRANCE_AROME, 0, datetime(2020, 6, 10).date()
-        )
+        _ = remote_files_grib_directories(recipe_arome)
     assert str(exc.value) == "Weather model does not offer grib data directories"
 
 
@@ -73,9 +69,7 @@ def test_build_remote_model_file_lists_wrong_weather_model():
     },
 )
 def test_build_remote_model_file_lists_for_package():
-    to_test = remote_files_grib_packages(
-        WeatherModels.METEO_FRANCE_AROME, 0, datetime(2020, 6, 10).date()
-    )
+    to_test = remote_files_grib_packages(recipe_arome)
     assert to_test == [
         "http://foobar.example.org/test_remote_file_2020061000_00_Package1.grib2.bz2",
         "http://foobar.example.org/test_remote_file_2020061000_01_Package1.grib2.bz2",
@@ -99,9 +93,7 @@ def test_build_remote_model_file_lists_for_package():
     },
 )
 def test_build_remote_file_list():
-    to_test = build_remote_file_list(
-        WeatherModels.METEO_FRANCE_AROME, 0, datetime(2020, 6, 10).date()
-    )
+    to_test = build_remote_file_list(recipe_arome)
     assert to_test == [
         "http://foobar.example.org/test_remote_file_2020061000_00_Package1.grib2.bz2",
         "http://foobar.example.org/test_remote_file_2020061000_01_Package1.grib2.bz2",
@@ -110,7 +102,5 @@ def test_build_remote_file_list():
 
 def test_build_remote_model_file_lists_for_package_wrong_model():
     with pytest.raises(WrongWeatherModelException) as excinfo:
-        _ = remote_files_grib_packages(
-            WeatherModels.DWD_ICON_EU, 0, datetime(2020, 6, 10).date()
-        )
+        _ = remote_files_grib_packages(recipe_icon)
     assert str(excinfo.value) == "Weather model does not offer grib data packages"

--- a/tests/unity/fixtures.py
+++ b/tests/unity/fixtures.py
@@ -1,5 +1,26 @@
 import os
+from datetime import datetime
 from pathlib import Path
+
+from gribmagic.unity.enumerations.weather_models import WeatherModels
+from gribmagic.unity.models import AcquisitionRecipe
+
+recipe_icon = AcquisitionRecipe(
+    model=WeatherModels.DWD_ICON_EU,
+    timestamp=datetime(2020, 6, 10, 0, 0),
+    target="/app/data",
+)
+recipe_arome = AcquisitionRecipe(
+    model=WeatherModels.METEO_FRANCE_AROME,
+    timestamp=datetime(2020, 6, 10, 0, 0),
+    target="/app/data",
+)
+recipe_harmonie = AcquisitionRecipe(
+    model=WeatherModels.KNMI_HARMONIE,
+    timestamp=datetime(2020, 6, 10, 0, 0),
+    target="/app/data",
+)
+
 
 testdata_path = Path(f"{os.getcwd()}/.gribmagic-testdata")
 

--- a/tests/unity/test_commands.py
+++ b/tests/unity/test_commands.py
@@ -20,7 +20,7 @@ model_config = deepcopy(MODEL_CONFIG[WeatherModels.DWD_ICON_EU.value])
 model_config.update({KEY_VARIABLES: ["air_temperature_2m", "relative_humidity_2m"]})
 
 
-def test_command_gribmagic_unity_list(capsys):
+def test_command_gribmagic_unity_list():
     runner = CliRunner()
     result = runner.invoke(
         cli=cli,
@@ -50,19 +50,44 @@ def test_command_gribmagic_unity_list(capsys):
     "gribmagic.unity.models.MODEL_CONFIG",
     {WeatherModels.DWD_ICON_EU.value: model_config},
 )
-def test_command_gribmagic_unity_acquire(caplog):
+def test_command_gribmagic_unity_acquire_success_cmdline(caplog, capsys):
 
-    responses.add(
-        method=responses.GET,
-        url=re.compile(".*"),
-        # No need to shuffle actual data around.
-        body=b"",
-        stream=True,
-    )
+    mock_response()
+
+    tempdir = tempfile.mkdtemp()
+    with caplog.at_level(logging.DEBUG):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli=cli,
+            args=[
+                "unity",
+                "acquire",
+                "--model=dwd-icon-eu",
+                "--timestamp=2021-10-03T00:00:00Z",
+                f"--target={tempdir}",
+            ],
+            catch_exceptions=False,
+        )
+
+    # result.exit_code == 1 -- why!?
+    # assert result.exit_code == 0
+
+    proof_success(caplog, result, tempdir)
+
+    shutil.rmtree(tempdir)
+
+
+@responses.activate
+@patch(
+    "gribmagic.unity.models.MODEL_CONFIG",
+    {WeatherModels.DWD_ICON_EU.value: model_config},
+)
+def test_command_gribmagic_unity_acquire_success_envvar(caplog, capsys):
+
+    mock_response()
 
     tempdir = tempfile.mkdtemp()
     with mock.patch.dict(os.environ, {"GM_DATA_PATH": tempdir}):
-
         with caplog.at_level(logging.DEBUG):
             runner = CliRunner()
             result = runner.invoke(
@@ -79,7 +104,50 @@ def test_command_gribmagic_unity_acquire(caplog):
     # result.exit_code == 1 -- why!?
     # assert result.exit_code == 0
 
-    assert "Starting GribMagic" in caplog.text
+    proof_success(caplog, result, tempdir)
+
+    shutil.rmtree(tempdir)
+
+
+@responses.activate
+@patch(
+    "gribmagic.unity.models.MODEL_CONFIG",
+    {WeatherModels.DWD_ICON_EU.value: model_config},
+)
+def test_command_gribmagic_unity_acquire_failure(caplog, capsys):
+
+    mock_response()
+
+    with caplog.at_level(logging.DEBUG):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli=cli,
+            args=[
+                "unity",
+                "acquire",
+                "--model=dwd-icon-eu",
+                "--timestamp=2021-10-03T00:00:00Z",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 2
+    assert "Error: Missing option '--target'." in result.output
+
+
+def mock_response():
+    responses.add(
+        method=responses.GET,
+        url=re.compile(".*"),
+        # No need to shuffle actual data around.
+        body=b"",
+        stream=True,
+    )
+
+
+def proof_success(caplog, result, tempdir):
+
+    assert "Starting GribMagic" in caplog.text, result.output
     assert (
         "WeatherModels.DWD_ICON_EU: Accessing parameter 'air_temperature_2m'"
         in caplog.messages
@@ -109,5 +177,3 @@ def test_command_gribmagic_unity_acquire(caplog):
     ]
     assert len(t2m_messages) == 93
     assert len(rh2m_messages) == 93
-
-    shutil.rmtree(tempdir)


### PR DESCRIPTION
Hi,

this patch adds the command line parameter `--target`. It can be used to designate the corresponding output directory, where data will be stored. The environment variable `GM_DATA_PATH` will also work.

With kind regards,
Andreas.
