### PR TITLE
Make modelrun (--timestamp parameter) optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ in progress
 - Integrate DWD GRIB Downloader as ``gribmagic dwd acquire`` subcommand
 - Add command to install the DWD GRIB Downloader at runtime:
   ``gribmagic install dwd-grib-downloader``.
+- Accept ``gribmagic dwd acquire`` without ``--timestamp`` parameter.
+  When the timestamp is omitted, the most recent available modelrun is used.
 
 
 2021-10-18 0.1.0

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ wget https://raw.githubusercontent.com/earthobservations/gribmagic/98da3fd4f/exa
 gribmagic dwd acquire --recipe=recipe_global_assorted.py --timestamp="2021101800" --output=.gribmagic-data
 ```
 
+When omitting the `--timestamp` parameter, the most recent modelrun is automatically selected.
+When omitting the `--output` parameter, it can be supplied using the `GM_DATA_PATH` environment variable.
+
+In this manner, the most compact form to invoke `gribmagic dwd` would be something like:
+```
+export GM_DATA_PATH=.gribmagic-data
+gribmagic dwd acquire --recipe=recipe_d2_wind.py
+```
 
 ## Run program in Docker
 

--- a/demo/acquire_and_bbox.sh
+++ b/demo/acquire_and_bbox.sh
@@ -13,7 +13,6 @@ function acquire() {
     echo "Downloading files"
     gribmagic dwd acquire \
       --recipe="examples/dwd/recipe_d2_wind.py" \
-      --timestamp="2021101712" \
       --output="${PATH_RAW}"
 }
 

--- a/docs/backlog.rst
+++ b/docs/backlog.rst
@@ -25,6 +25,7 @@ Prio 1
 ******
 Prio 2
 ******
+- [o] Integrate ``demo/grib_bbox.py``
 - [o] Add type hints for return values from "download-xyz" functions
 - [o] ``--dry-run`` parameter, just printing the index files and URLs
 - [o] Notify upstream about troubles with SkinnyWMS and Xpublish

--- a/docs/backlog.rst
+++ b/docs/backlog.rst
@@ -6,6 +6,7 @@ GribMagic backlog
 ******
 Prio 1
 ******
+- [o] Complete pipeline demos
 - [o] Integrate regridding
     - https://github.com/jbusecke/cmip6_preprocessing/issues/38
     - https://github.com/DeutscherWetterdienst/regrid
@@ -102,3 +103,4 @@ Done
       into ``gribmagic.dwd`` module and as ``gribmagic dwd acquire`` subcommand.
 - [x] Unlock ICON-D2
 - [x] Download only specific parameters
+- [x] Use most recent modelrun

--- a/gribmagic/dwd/pipeline.py
+++ b/gribmagic/dwd/pipeline.py
@@ -21,7 +21,7 @@ import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import click
 
@@ -115,7 +115,9 @@ class DwdDownloader:
         """
 
         # Compute timestamp.
+        logger.info(f"Using designated timestamp: {self.timestamp}")
         timestamp = self.get_most_recent_timestamp(model=model, modelrun=self.timestamp)
+        logger.info(f"Using effective timestamp: {timestamp}")
 
         # Default for "single-level" parameters.
         if level == "single-level":
@@ -178,14 +180,15 @@ def process(recipe: Recipe, timestamp: str, output: Path):
 @click.option(
     "--recipe", type=click.Path(exists=True, file_okay=True), help="The recipe file", required=True
 )
-@click.option("--timestamp", type=str, help="The timestamp/modelrun", required=True)
+@click.option("--timestamp", type=str, help="The timestamp/modelrun", required=False)
 @click.option(
     "--output",
     type=click.Path(exists=False, file_okay=False, dir_okay=True),
+    envvar="GM_DATA_PATH",
     help="The output directory",
     required=True,
 )
-def main(recipe: Path, timestamp: str, output: Path):
+def main(recipe: Path, timestamp: Optional[str], output: Path):
 
     # Setup logging.
     setup_logging(logging.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,9 @@ setup(name='gribmagic',
           "mock>=4,<5",
           "responses>=0.12,<1",
         ],
+        "plotting": [
+          "Magics==1.5.6",
+        ],
       },
       entry_points={
         'console_scripts': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+
+if "GM_DATA_PATH" in os.environ:
+    del os.environ["GM_DATA_PATH"]

--- a/tests/dwd/test_pipeline.py
+++ b/tests/dwd/test_pipeline.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.dwd.util import (
     previous_modelrun,
     run_icon_d2_vmax_recipe,
@@ -5,52 +7,39 @@ from tests.dwd.util import (
 )
 
 
-def test_dwd_icon_d2_success():
+@pytest.mark.parametrize("run_recipe", [run_icon_d2_vmax_recipe, run_icon_global_temp2m_recipe])
+def test_dwd_previous_modelrun_success(run_recipe):
 
     # Use the previous model run, 6 hours ago.
     modelrun = previous_modelrun()
 
     # Run data acquisition.
-    results = run_icon_d2_vmax_recipe(modelrun)
+    results = run_recipe(modelrun)
 
     # Check outcome.
     outcome = all(outcome["file"] is not None for outcome in results)
     assert outcome is True
 
 
-def test_dwd_icon_d2_modelrun_expired():
-
-    # Use a timestamp in the past, 2021-10-05T00
-    modelrun = "2021100500"
+@pytest.mark.parametrize("run_recipe", [run_icon_d2_vmax_recipe, run_icon_global_temp2m_recipe])
+def test_dwd_no_modelrun_success(run_recipe):
 
     # Run data acquisition.
-    results = run_icon_d2_vmax_recipe(modelrun)
-
-    # Check outcome.
-    outcome = any(outcome["file"] is not None for outcome in results)
-    assert outcome is False
-
-
-def test_dwd_icon_global_success():
-
-    # Use the previous model run, 6 hours ago.
-    modelrun = previous_modelrun()
-
-    # Run data acquisition.
-    results = run_icon_global_temp2m_recipe(modelrun)
+    results = run_recipe(None)
 
     # Check outcome.
     outcome = all(outcome["file"] is not None for outcome in results)
     assert outcome is True
 
 
-def test_dwd_icon_global_modelrun_expired():
+@pytest.mark.parametrize("run_recipe", [run_icon_d2_vmax_recipe, run_icon_global_temp2m_recipe])
+def test_dwd_modelrun_expired(run_recipe):
 
     # Use a timestamp in the past, 2021-10-05T00
     modelrun = "2021100500"
 
     # Run data acquisition.
-    results = run_icon_global_temp2m_recipe(modelrun)
+    results = run_recipe(modelrun)
 
     # Check outcome.
     outcome = any(outcome["file"] is not None for outcome in results)

--- a/tests/dwd/util.py
+++ b/tests/dwd/util.py
@@ -1,4 +1,5 @@
 import operator
+import re
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -41,9 +42,8 @@ def run_icon_d2_vmax_recipe(modelrun):
 
         results = sorted(results, key=operator.itemgetter("url"))
         url = results[0]["url"]
-        assert (
-            f"icon-d2_germany_regular-lat-lon_single-level_{modelrun}_000_2d_vmax_10m.grib2.bz2"
-            in url
+        assert re.match(
+            r".*icon-d2_germany_regular-lat-lon_single-level_\d+_000_2d_vmax_10m.grib2.bz2", url
         ), url
 
         return results
@@ -63,6 +63,6 @@ def run_icon_global_temp2m_recipe(modelrun):
 
         results = sorted(results, key=operator.itemgetter("url"))
         url = results[0]["url"]
-        assert f"icon_global_icosahedral_single-level_{modelrun}_000_T_2M.grib2.bz2" in url, url
+        assert re.match(r".*icon_global_icosahedral_single-level_\d+_000_T_2M.grib2.bz2", url), url
 
         return results


### PR DESCRIPTION
When omitting the `--timestamp` parameter, the most recent modelrun is automatically selected.