### PR TITLE
Add subcommand `gribmagic smith regrid`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,12 +38,19 @@ jobs:
     - name: Acquire sources
       uses: actions/checkout@v2
 
-    - uses: actions/cache@v2
+    - name: Cache Python packages
+      uses: actions/cache@v2
       with:
         path: ${{ matrix.path }}
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'requirements-dev.txt') }}
-        restore-keys: |
-         ${{ runner.os }}-pip-
+
+    - name: Cache programs and data
+      uses: actions/cache@v2
+      with:
+        path: |
+          /home/runner/.local/share/gribmagic
+          .gribmagic-testdata/input
+        key: programs-data-${{ hashFiles('gribmagic.mk') }}
 
     - name: Install dependencies
       run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,10 @@ in progress
   ``gribmagic install dwd-grib-downloader``.
 - [dwd] Accept ``gribmagic dwd acquire`` without ``--timestamp`` parameter.
   When the timestamp is omitted, the most recent available modelrun is used.
-- [dwd] Add subcommand ``gribmagic smith bbox``, in order to extract an area of
+- [tool] Add subcommand ``gribmagic smith bbox``, in order to extract an area of
   interest from GRIB files using a bounding box, or a two-letter country code.
+- [tool] Add subcommand ``gribmagic smith regrid``, in order to transform DWD ICON's
+  icosahedral-gridded files into regular grids in ``long1`` format.
 
 
 2021-10-18 0.1.0

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ setup-virtualenv:
 
 # Run the main test suite
 test: install-tests
+	@echo "==================="
+	@echo "Invoking test suite"
+	@echo "==================="
 	@$(pytest) -vvv tests
 
 test-refresh: install-tests test
@@ -37,6 +40,9 @@ test-junit: install-tests
 	@$(pytest) tests --junit-xml .pytest_results/pytest.xml
 
 test-coverage: install-tests
+	@echo "==================="
+	@echo "Invoking test suite"
+	@echo "==================="
 	@$(pytest) -vvv tests \
 		--cov=gribmagic --cov-branch \
 		--cov-report=term-missing \
@@ -97,11 +103,21 @@ install-releasetools: setup-virtualenv
 	@$(pip) install --quiet --requirement requirements-dev.txt --upgrade
 
 install-tests: setup-virtualenv testdata-download testoutput-clean
+
+	@mkdir -p .pytest_results
+
+	@echo "========================================"
+	@echo "Installing/upgrading sandbox environment"
+	@echo "========================================"
 	@$(pip) install --quiet --editable=.[test,plotting] --upgrade
 	@$(MAKE) magics-info
+	@echo
+
+	@echo "=============================="
+	@echo "Installing DWD GRIB Downloader"
+	@echo "=============================="
 	@$(gribmagic) install dwd-grib-downloader
-	@touch $(venvpath)/bin/activate
-	@mkdir -p .pytest_results
+	@echo
 
 
 # ==============

--- a/README.md
+++ b/README.md
@@ -152,6 +152,32 @@ gribmagic smith bbox \
   --plot
 ```
 
+
+## Run regridding tool
+
+Acquire grid information files.
+```
+gribmagic install dwd-grid-information
+```
+
+Process regridding on a single file. The default is to assume ICON GLOBAL files and the
+regridding will take place with 0.250° resolution.
+```
+gribmagic smith regrid \
+  ".gribmagic-data/raw/icon/**/*icon_global_icosahedral*.grib2" \
+  --output=.gribmagic-data/regridded/icon-global
+```
+
+When aiming to regrid with 0.125° resolution, please specify the `--resolution=0.125` argument, like:
+```
+gribmagic smith regrid \
+  ".gribmagic-data/raw/icon/**/*icon_global_icosahedral*.grib2" \
+  --output=.gribmagic-data/regridded/icon-global \
+  --resolution=0.125
+```
+
+
+
 ## Run program in Docker
 
 To use GribMagic in a Docker container, you have to build the Docker image like
@@ -179,6 +205,9 @@ make test
 
 # All tests, with code coverage report.
 make test-coverage
+
+# Run specific tests, with coverage report.
+.venv/bin/pytest -vvv --cov-report=term-missing --cov=gribmagic.smith.regrid -k test_regrid
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ gribmagic install dwd-grib-downloader
 
 # Acquire wind-specific parameters from ICON-D2.
 wget https://raw.githubusercontent.com/earthobservations/gribmagic/98da3fd4f/examples/dwd/recipe_d2_wind.py
-gribmagic dwd acquire --recipe=recipe_d2_wind.py --timestamp="2021101800" --output=.gribmagic-data
+gribmagic dwd acquire --recipe=recipe_d2_wind.py --timestamp="2021101800" --output=.gribmagic-data/raw
 
 # Acquire assorted parameters from ICON-GLOBAL.
 wget https://raw.githubusercontent.com/earthobservations/gribmagic/98da3fd4f/examples/dwd/recipe_global_assorted.py
-gribmagic dwd acquire --recipe=recipe_global_assorted.py --timestamp="2021101800" --output=.gribmagic-data
+gribmagic dwd acquire --recipe=recipe_global_assorted.py --timestamp="2021101800" --output=.gribmagic-data/raw
 ```
 
 When omitting the `--timestamp` parameter, the most recent modelrun is automatically selected.
@@ -106,7 +106,7 @@ When omitting the `--output` parameter, it can be supplied using the `GM_DATA_PA
 
 In this manner, the most compact form to invoke `gribmagic dwd` would be something like:
 ```
-export GM_DATA_PATH=.gribmagic-data
+export GM_DATA_PATH=.gribmagic-data/raw
 gribmagic dwd acquire --recipe=recipe_d2_wind.py
 ```
 
@@ -116,14 +116,16 @@ Extract area of interest from GRIB files using a bounding box.
 Extract subset by coordinates, a space-separated list of `lat_min lat_max lon_min lon_max`.
 ```
 gribmagic smith bbox \
-  ".gribmagic-data/raw/icon-d2/**/*regular-lat-lon*.grib2" --output=.gribmagic-data/subgrid \
+  ".gribmagic-data/raw/icon-d2/**/*regular-lat-lon*.grib2" \
+  --output=.gribmagic-data/subgrid/icon-d2 \
   --bbox=46.0 47.5 14.5 16.8
 ```
 
 Extract subset by 2-letter country name.
 ```
 gribmagic smith bbox \
-  ".gribmagic-data/raw/icon-d2/**/*regular-lat-lon*.grib2" --output=.gribmagic-data/subgrid \
+  ".gribmagic-data/raw/icon-d2/**/*regular-lat-lon*.grib2" \
+  --output=.gribmagic-data/subgrid/icon-d2 \
   --country=AT
 ```
 
@@ -144,7 +146,8 @@ pip install gribmagic[plotting]
 and use the `--plot` option:
 ```
 gribmagic smith bbox \
-  ".gribmagic-data/raw/icon-d2/**/*regular-lat-lon*.grib2" --output=.gribmagic-data/subgrid \
+  ".gribmagic-data/raw/icon-d2/**/*regular-lat-lon*.grib2" \
+  --output=.gribmagic-data/subgrid \
   --country=AT \
   --plot
 ```

--- a/docs/backlog.rst
+++ b/docs/backlog.rst
@@ -26,6 +26,9 @@ Prio 1
         - Versions of Numpy, cfgrib, xarray, Dask
         - Magics version: Magics.version().decode()
         - cdo and eccodes versions
+- [o] Load asset files from different directory than ``appdirs_user()``.
+- [o] GFS API: https://github.com/jagoosw/getgfs
+
 
 
 ******
@@ -51,6 +54,8 @@ Prio 2
         - https://ufscommunity.org/news/srwa/
     - Unlock ERA5 and TIGGE
 - [o] Implement ``gribmagic/unity/modules/parsing/unify_data.py``
+- [o] What about https://opendata.dwd.de/weather/lib/grib/eccodes_definitions.edzw-2.22.1-1.tar.bz2 ?
+- [o] Elevation data from https://github.com/bopen/elevation?
 
 
 ******

--- a/gribmagic.mk
+++ b/gribmagic.mk
@@ -11,6 +11,8 @@ testdata-download:
 	@echo "===================="
 	mkdir -p $(PATH_TESTDATA_INPUT)
 	mkdir -p $(PATH_TESTDATA_OUTPUT)
+	wget https://github.com/earthobservations/testdata/raw/main/opendata.dwd.de/weather/nwp/icon/grib/18/vmax_10m/icon_global_icosahedral_single-level_2021102018_001_VMAX_10M.grib2 \
+	    --directory-prefix $(PATH_TESTDATA_INPUT) --no-clobber
 	wget https://github.com/earthobservations/testdata/raw/main/opendata.dwd.de/weather/nwp/icon/grib/18/t/icon-global_regular-lat-lon_air-temperature_level-90.grib2 \
 	    --directory-prefix $(PATH_TESTDATA_INPUT) --no-clobber
 	wget https://github.com/earthobservations/testdata/raw/main/opendata.dwd.de/weather/nwp/icon-eu/grib/00/t_2m/icon-eu_europe_regular-lat-lon_single-level_2020062300_000_T_2M.grib2.bz2 \

--- a/gribmagic.mk
+++ b/gribmagic.mk
@@ -29,6 +29,8 @@ testoutput-clean:
 	@echo
 
 magics-install:
+	# Downloads and install Magics release from https://confluence.ecmwf.int/display/MAGP/Releases.
+	# Needs `apt-get install --yes build-essential cmake libeccodes-dev libeccodes-tools libproj-dev libexpat-dev libcairo2-dev libpangocairo-1.0-0`.
 	$(eval TMP := tmp/magics)
 	mkdir -p ${TMP}/download ${TMP}/build/${MAGICS_VERSION}
 	wget https://confluence.ecmwf.int/download/attachments/3473464/Magics-${MAGICS_VERSION}-Source.tar.gz \
@@ -39,6 +41,7 @@ magics-install:
 	    cmake \
 	        -DCMAKE_INSTALL_PREFIX=${MAGICS_PREFIX} \
 	        -DPYTHON_EXECUTABLE=$(shell which python3) \
+	        -DENABLE_TESTS=off \
 	        ../../download/Magics-${MAGICS_VERSION}-Source; \
 	    make -j8 && make install
 
@@ -62,6 +65,8 @@ magics-info:
 	@printf "Library: "
 	@$(python) -c "import Magics; print(Magics.dll)" || true
 	@printf ""
+
+	@echo
 
 install-skinnywms-macos-10-13:
 	wget https://files.pythonhosted.org/packages/e9/2f/28cdbfbf7165d89c4c574babe7ac12e994266e03fe3cae201d63cc0f471a/ecmwflibs-0.0.94-cp38-cp38-macosx_10_14_x86_64.whl

--- a/gribmagic/commands.py
+++ b/gribmagic/commands.py
@@ -10,6 +10,7 @@ import click
 import gribmagic.dwd.download
 import gribmagic.installer
 import gribmagic.smith.bbox
+import gribmagic.smith.regrid.cli
 from gribmagic.unity.configuration.parser import parse_model_config
 from gribmagic.unity.core import run_model_download
 from gribmagic.unity.enumerations import WeatherModel
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 # The logging has to be configured on the module level
 # in order to make it apply in ProcessPoolExecutor contexts.
 # https://stackoverflow.com/a/49791106
-setup_logging()
+setup_logging(level=logging.DEBUG)
 
 
 @click.group()
@@ -80,3 +81,4 @@ def smith(ctx):
 
 
 smith.add_command(gribmagic.smith.bbox.main, "bbox")
+smith.add_command(gribmagic.smith.regrid.cli.main, "regrid")

--- a/gribmagic/installer.py
+++ b/gribmagic/installer.py
@@ -30,5 +30,16 @@ def install_package(name: str):
             git clone --branch=amo/develop https://github.com/earthobservations/dwd-grib-downloader '{DWD_GRIB_DOWNLOADER_PATH}' 
         """.strip()
         os.system(command)
+
+    elif name == "dwd-grid-information":
+        from gribmagic.smith.regrid.engine import GridTransformationLibrary
+        from gribmagic.smith.regrid.model import GRID_METADATA_PATH
+
+        logger.info(f"Installing grid information files to '{GRID_METADATA_PATH}'")
+        for item in GridTransformationLibrary.description_weight_files:
+            item.install()
+        for item in GridTransformationLibrary.grid_files:
+            item.install()
+
     else:
         raise ValueError(f"Unknown package {name}")

--- a/gribmagic/smith/bbox.py
+++ b/gribmagic/smith/bbox.py
@@ -355,6 +355,9 @@ class GRIBSubset:
         :param infile: Path to input file
         :return: Path to output file
         """
+
+        # Suppress banner output on STDOUT.
+        os.environ["MAGPLUS_QUIET"] = "true"
         from Magics import macro as magics
 
         # Compute outfile location.

--- a/gribmagic/smith/regrid/cli.py
+++ b/gribmagic/smith/regrid/cli.py
@@ -1,0 +1,66 @@
+import json
+import logging
+from pathlib import Path
+from typing import List
+
+import click
+
+from gribmagic.smith.regrid.engine import GridTransformationLibrary, RegridTransformer
+from gribmagic.smith.util import ProcessingResult, json_serializer
+from gribmagic.util import setup_logging
+
+
+@click.command(help=RegridTransformer.__doc__)
+@click.argument("input", type=click.Path(file_okay=True, dir_okay=True), required=True, nargs=-1)
+@click.option(
+    "--output",
+    envvar="GM_DATA_PATH",
+    type=click.Path(exists=False, file_okay=False, dir_okay=True),
+    help="The output directory",
+    required=True,
+)
+@click.option(
+    "--kind", help="Which grid kind to select. Use `global`", required=False, default="global"
+)
+@click.option(
+    "--resolution",
+    type=float,
+    help="Which resolution to select. Use `0.125` or `0.25`",
+    required=False,
+    default=0.25,
+)
+@click.option(
+    "--dry-run", is_flag=True, help="Whether to simulate processing", required=False, default=False
+)
+def main(
+    input: List[Path],
+    output: Path,
+    kind: str,
+    resolution: float,
+    dry_run: bool,
+):
+
+    # Setup logging.
+    setup_logging(level=logging.DEBUG)
+
+    # Invoke the machinery.
+
+    # Load grid transformation asset files.
+    gridlib = GridTransformationLibrary()
+    gridinfo = gridlib.get_info(kind=kind, resolution_dw=resolution)
+
+    # Extend output path with resolution.
+    resolution_label = str(int(resolution * 1000))
+    output = Path(output).joinpath(resolution_label)
+
+    # Transform grid / regrid.
+    transformer = RegridTransformer(gridinfo=gridinfo, input=input, output=output, dry_run=dry_run)
+    transformer.setup()
+    results: List[ProcessingResult] = transformer.process()
+
+    # Report about the outcome.
+    print(json.dumps(results, default=json_serializer, indent=4))
+
+
+if __name__ == "__main__":  # pragma: nocover
+    main()

--- a/gribmagic/smith/regrid/engine.py
+++ b/gribmagic/smith/regrid/engine.py
@@ -1,0 +1,260 @@
+import logging
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from pathlib import Path
+from typing import Any, List, Union
+
+from cdo import Cdo
+
+from gribmagic.smith.regrid.model import (
+    GridDescriptionWeight,
+    GridFile,
+    GridInformation,
+    GridKind,
+    logger,
+)
+from gribmagic.smith.util import FileProcessor, ProcessingResult
+
+logger = logging.getLogger(__name__)
+
+
+class GridTransformationLibrary:
+    """
+    Die notwendigen Dateien zur Transformation von ICON-Daten vom nativen
+    Dreiecksgitter in ein reguläres Lat/Lon-Gitter (Gitterinformationsdatei des
+    globalen Modells ICON, die Gitterbeschreibungen und die berechneten
+    Interpolationsgewichte):
+
+        ICON_GLOBAL2WORLD_0125_EASY.tar.bz2
+        ICON_GLOBAL2WORLD_025_EASY.tar.bz2
+        ICON_GLOBAL2EUAU_025_EASY.tar.bz2
+        ICON_GLOBAL2EUAU_0125_EASY.tar.bz2
+        icon_grid_0026_R03B07_G.bz2
+
+    Für weitere Informationen verweisen wir auf:
+
+        https://www.dwd.de/DE/leistungen/opendata/hilfe.html#doc625266bodyText13
+        https://www.dwd.de/DE/leistungen/opendata/help/modelle/Opendata_cdo_DE.pdf?__blob=publicationFile
+        https://www.dwd.de/DE/leistungen/opendata/help/modelle/Opendata_cdo_EN.pdf?__blob=publicationFile
+
+    Informationen über die entsprechenden Ressourcen finden sich auf dem DWD Open Data Server unter:
+
+        https://opendata.dwd.de/weather/lib/README.txt
+        https://opendata.dwd.de/weather/lib/cdo/
+        http://icon-downloads.zmaw.de/dwd_grids.xml
+    """
+
+    description_weight_files = [
+        GridDescriptionWeight(
+            kind=GridKind.ICON_GLOBAL2WORLD_0125,
+            resolution=0.125,
+            url="https://opendata.dwd.de/weather/lib/cdo/ICON_GLOBAL2WORLD_0125_EASY.tar.bz2",
+            description="target_grid_world_0125.txt",
+            weights="weights_icogl2world_0125.nc",
+        ),
+        GridDescriptionWeight(
+            kind=GridKind.ICON_GLOBAL2WORLD_025,
+            resolution=0.250,
+            url="https://opendata.dwd.de/weather/lib/cdo/ICON_GLOBAL2WORLD_025_EASY.tar.bz2",
+            description="target_grid_world_025.txt",
+            weights="weights_icogl2world_025.nc",
+        ),
+        GridDescriptionWeight(
+            kind=GridKind.ICON_GLOBAL2EUAU_0125,
+            resolution=0.125,
+            url="https://opendata.dwd.de/weather/lib/cdo/ICON_GLOBAL2EUAU_0125_EASY.tar.bz2",
+            description="target_grid_EUAU_0125.txt",
+            weights="weights_icogl2world_0125_EUAU.nc",
+        ),
+        GridDescriptionWeight(
+            kind=GridKind.ICON_GLOBAL2EUAU_025,
+            resolution=0.250,
+            url="https://opendata.dwd.de/weather/lib/cdo/ICON_GLOBAL2EUAU_025_EASY.tar.bz2",
+            description="target_grid_EUAU_025.txt",
+            weights="weights_icogl2world_025_EUAU.nc",
+        ),
+    ]
+
+    grid_files = [
+        GridFile(
+            kinds=[GridKind.ICON_GLOBAL2WORLD_0125, GridKind.ICON_GLOBAL2WORLD_025],
+            resolution=13,
+            url="https://opendata.dwd.de/weather/lib/cdo/icon_grid_0026_R03B07_G.nc.bz2",
+            identifier="R03B07_G",
+            description="Global R03B07 grid. 13 km resolution.",
+        ),
+        GridFile(
+            kinds=[GridKind.ICON_GLOBAL2WORLD_0125, GridKind.ICON_GLOBAL2WORLD_025],
+            resolution=40,
+            url="https://opendata.dwd.de/weather/lib/cdo/icon_grid_0024_R02B06_G.nc.bz2",
+            identifier="R02B06_G",
+            description="Global R02B06 grid. 40 km resolution.",
+        ),
+        GridFile(
+            kinds=[GridKind.ICON_GLOBAL2EUAU_0125, GridKind.ICON_GLOBAL2EUAU_025],
+            resolution=20,
+            url="https://opendata.dwd.de/weather/lib/cdo/icon_grid_0028_R02B07_N02.nc.bz2",
+            identifier="R02B07_N02",
+            description="Regional R02B07 grid (Europe). 20 km resolution.",
+        ),
+        GridFile(
+            kinds=Any,
+            resolution=2,
+            url="https://opendata.dwd.de/weather/lib/cdo/icon_grid_0047_R19B07_L.nc.bz2",
+            identifier="R19B07_L",
+            description="Limited area grid (Germany): Enhanced COSMO-D2 area with 2 km resolution.",
+        ),
+    ]
+
+    def get_info(
+        self, kind: Union[GridKind, str], resolution_dw: float, resolution_grid: int = None
+    ):
+        """
+        Get composite information needed for a transformation/regridding process.
+        That is, the grid itself accompanied by its description/weight information.
+
+        :param kind: Any of GridKind
+        :param resolution_dw: A resolution in degrees (0.125 or 0.250) for the icosahedral data.
+                              This is needed for selecting the right description & weight info.
+        :param resolution_grid: A resolution in kilometres (13, 40, 20, 2) for the latlon-gridded data.
+                                This is needed for selecting the grid info.
+        :return:
+        """
+        kind = self.kind_from_model(model=kind, resolution=resolution_dw)
+        info = GridInformation(
+            description_weight=self.get_description_weight(kind=kind, resolution=resolution_dw),
+            grid=self.get_grid(kind=kind, resolution=resolution_grid),
+        )
+        return info
+
+    def get_description_weight(self, kind: GridKind, resolution: float = None):
+        for description_weight in self.description_weight_files:
+            if description_weight.kind == kind:
+                if resolution is None or description_weight.resolution == resolution:
+                    return description_weight
+
+    def get_grid(self, kind: GridKind, resolution: int = None):
+        for grid_file in self.grid_files:
+            if kind is Any or kind in grid_file.kinds:
+                if resolution is None or grid_file.resolution == resolution:
+                    return grid_file
+
+    @staticmethod
+    def kind_from_model(model: str, resolution: float):
+
+        model = model.lower()
+
+        # TODO: Improve heuristics.
+        if "global" in model:
+            if resolution == 0.125:
+                kind = GridKind.ICON_GLOBAL2WORLD_0125
+            elif resolution == 0.250:
+                kind = GridKind.ICON_GLOBAL2WORLD_025
+            else:
+                raise ValueError("Unknown grid resolution requested")
+
+        # TODO: Improve heuristics.
+        elif "eu" in model:
+            if resolution == 0.125:
+                kind = GridKind.ICON_GLOBAL2EUAU_0125
+            elif resolution == 0.250:
+                kind = GridKind.ICON_GLOBAL2EUAU_025
+            else:
+                raise ValueError("Unknown grid resolution requested")
+        else:
+            raise ValueError("Unknown grid kind requested")
+        return kind
+
+
+class RegridTransformer:
+    """
+    Perform grid transformation and coordinate rearrangement on GRIB data.
+
+    This is suitable for bringing ICON GLOBAL NWP data into the form of a regular grid.
+
+    1. Transform from "icosahedral" to "regular-lat-lon" grid.
+        - https://code.mpimet.mpg.de/projects/cdo/wiki/Tutorial#Interpolation
+        - https://www.dwd.de/DWD/forschung/nwv/fepub/icon_database_main.pdf
+        - https://www.dwd.de/DE/leistungen/opendata/help/modelle/Opendata_cdo_DE.pdf?__blob=publicationFile
+        - https://www.dwd.de/DE/leistungen/opendata/help/modelle/Opendata_cdo_EN.pdf?__blob=publicationFile
+        - https://opendata.dwd.de/weather/lib/cdo/
+
+    2. Rearrange coordinates data from longitude 0 to 360 degrees (long3) to -180 to 180 degrees (long1).
+        - https://code.mpimet.mpg.de/projects/cdo/wiki/Tutorial#Basic-Usage
+        - https://confluence.ecmwf.int/pages/viewpage.action?pageId=149337515
+        - https://gis.stackexchange.com/questions/201789/verifying-formula-that-will-convert-longitude-0-360-to-180-to-180
+    """
+
+    def __init__(
+        self, gridinfo: GridInformation, input: List[Path], output: Path, dry_run: bool = False
+    ):
+        self.gridinfo = gridinfo
+        self.input = input
+        self.output = Path(output)
+        self.dry_run = dry_run
+        with redirect_stdout(sys.stderr):
+            self.cdo = Cdo(logging=True, debug=False)
+
+    def setup(self):
+        logger.info(
+            f'Using grid information "{self.gridinfo.grid.description}" with "{self.gridinfo.description_weight.description}" and "{self.gridinfo.description_weight.weights}"'
+        )
+        if not self.dry_run:
+            self.gridinfo.description_weight.install()
+            self.gridinfo.grid.install()
+
+    def process(self) -> List[ProcessingResult]:
+        """
+        Process all input files.
+
+        :return: List of ``ProcessingResult`` instances
+        """
+
+        processor = FileProcessor(input=self.input, method=self.step)
+        return processor.resolve().run()
+
+    def step(self, item: ProcessingResult) -> None:
+
+        filename = item.input.stem
+        item.output = self.output / f"{filename}-latlon-long1.grib2"
+
+        logger.info(f"Invoke regridding on {filename}")
+
+        if self.dry_run:
+            return
+
+        if item.output.exists():
+            logger.debug(f"[rearr] Skipping existing file: {item.output}")
+            return
+
+        tmpfile = tempfile.NamedTemporaryFile(prefix=f"{filename}-latlon-long3_", suffix=".grib2")
+
+        # 1. Transform from "icosahedral" to "regular-lat-lon" grid.
+        long3file = Path(tmpfile.name)
+
+        logger.info(f"""[remap] Transforming from "icosahedral" to "regular-lat-lon" grid""")
+        logger.debug(f"[remap] Processing infile={item.input}, outfile={long3file}")
+
+        if not self.dry_run:
+            self.cdo.remap(
+                f'"{self.gridinfo.description_weight.description_file}"',
+                f'"{self.gridinfo.description_weight.weights_file}"',
+            ).setgrid(
+                f'"{self.gridinfo.grid.gridfile}"',
+                input=str(item.input),
+                output=str(long3file),
+            )
+
+            # .setmisstoc(0) \
+
+        # 2. Rearrange coordinates data from longitude 0 to 360 degrees (long3) to -180 to 180 degrees (long1).
+        infile = long3file
+        logger.info('[rearr] Rearranging coordinates from "long3" to "long1"')
+        logger.debug(f"[rearr] Processing infile={infile}, outfile={long3file}")
+
+        self.output.mkdir(parents=True, exist_ok=True)
+
+        self.cdo.sellonlatbox(-180, 180, -90, 90, input=str(infile), output=str(item.output))
+
+        logger.info(f"[rearr] Regridded file is {long3file}")

--- a/gribmagic/smith/regrid/model.py
+++ b/gribmagic/smith/regrid/model.py
@@ -1,0 +1,95 @@
+import dataclasses
+import logging
+from enum import Enum
+from pathlib import Path
+from typing import List
+
+import appdirs
+
+from gribmagic.util import run_command
+
+logger = logging.getLogger(__name__)
+
+GRID_METADATA_PATH = (
+    Path(appdirs.user_data_dir("gribmagic", "earthobservations")) / "metadata" / "grid"
+)
+
+
+class GridKind(Enum):
+    ICON_GLOBAL2WORLD_0125 = "ICON_GLOBAL2WORLD_0125"
+    ICON_GLOBAL2WORLD_025 = "ICON_GLOBAL2WORLD_025"
+    ICON_GLOBAL2EUAU_0125 = "ICON_GLOBAL2EUAU_0125"
+    ICON_GLOBAL2EUAU_025 = "ICON_GLOBAL2EUAU_025"
+
+
+@dataclasses.dataclass
+class GridDescriptionWeight:
+    kind: GridKind
+    url: str
+    resolution: float
+    description: str
+    weights: str
+
+    def __post_init__(self):
+        self.name = Path(self.url).name.replace(".tar.bz2", "")
+        self.basedir = GRID_METADATA_PATH / self.name
+        self.description_file = self.basedir / self.description
+        self.weights_file = self.basedir / self.weights
+
+    def install(self, force=False):
+        """
+        Ensure auxiliary data needed for regridding is present.
+        """
+
+        if not force and (self.weights_file.exists() and self.description_file.exists()):
+            logger.info(f"Grid description and weight files for {self.name} already downloaded")
+            return
+
+        logger.info(f"Installing grid description and weight files {self.name} from {self.url}")
+
+        run_command(f"""wget --continue --directory-prefix='{GRID_METADATA_PATH}' {self.url}""")
+
+        run_command(
+            f"""test ! -d '{self.basedir}' && tar -C '{GRID_METADATA_PATH}' -xjf '{self.basedir}.tar.bz2'"""
+        )
+
+
+@dataclasses.dataclass
+class GridFile:
+    """
+    - http://icon-downloads.zmaw.de/dwd_grids.xml
+    - https://code.mpimet.mpg.de/boards/1/topics/5490
+    """
+
+    kinds: List[GridKind]
+    # Resolution in km
+    resolution: int
+    url: str
+    identifier: str
+    description: str
+
+    def __post_init__(self):
+        self.name = Path(self.url).name.replace(".bz2", "")
+        self.basedir = GRID_METADATA_PATH
+        self.gridfile = self.basedir / self.name
+
+    def install(self, force=False):
+        """
+        Ensure auxiliary data needed for regridding is present.
+        """
+
+        if not force and (self.gridfile.exists()):
+            logger.info(f"Grid information files for {self.name} already downloaded")
+            return
+
+        logger.info(f"Installing grid information files {self.name} from {self.url}")
+
+        run_command(f"""wget --continue --directory-prefix='{GRID_METADATA_PATH}' {self.url}""")
+
+        run_command(f"""test ! -f '{self.gridfile}' && bunzip2 '{self.gridfile}.bz2'""")
+
+
+@dataclasses.dataclass
+class GridInformation:
+    description_weight: GridDescriptionWeight
+    grid: GridFile

--- a/gribmagic/smith/util.py
+++ b/gribmagic/smith/util.py
@@ -1,0 +1,66 @@
+import dataclasses as dataclasses
+import logging
+from pathlib import Path
+from typing import Callable, List
+
+from setuptools import glob
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class ProcessingResult:
+    """
+    This holds information about the
+    result from processing a single file.
+    """
+
+    input: Path
+    output: Path = None
+    plot: Path = None
+
+
+def json_serializer(obj):
+    """
+    JSON serializer for custom objects not serializable by default json code
+    """
+
+    if isinstance(obj, ProcessingResult):
+        return dataclasses.asdict(obj)
+    elif isinstance(obj, Path):
+        return str(obj)
+
+
+@dataclasses.dataclass
+class FileProcessor:
+
+    input: List[Path]
+    method: Callable
+
+    def resolve(self) -> List[Path]:
+        """
+        Resolve wildcards from list of input files.
+
+        :return: List of resolved Path items.
+        """
+        input_paths = []
+        for path_raw in self.input:
+            path = glob.glob(str(path_raw), recursive=True)
+            input_paths += path
+        self.input = list(map(Path, input_paths))
+        return self
+
+    def run(self) -> List[ProcessingResult]:
+        """
+        Process all input files.
+
+        :return: List of ``ProcessingResult`` instances
+        """
+        results: List[ProcessingResult] = []
+        for infile in self.input:
+            logger.info(f"Processing file {infile}")
+            item = ProcessingResult(input=infile)
+            self.method(item)
+            results.append(item)
+
+        return results

--- a/gribmagic/smith/util.py
+++ b/gribmagic/smith/util.py
@@ -1,5 +1,7 @@
 import dataclasses as dataclasses
 import logging
+import sys
+from contextlib import redirect_stdout
 from pathlib import Path
 from typing import Callable, List
 
@@ -60,7 +62,8 @@ class FileProcessor:
         for infile in self.input:
             logger.info(f"Processing file {infile}")
             item = ProcessingResult(input=infile)
-            self.method(item)
+            with redirect_stdout(sys.stderr):
+                self.method(item)
             results.append(item)
 
         return results

--- a/gribmagic/smith/util.py
+++ b/gribmagic/smith/util.py
@@ -45,8 +45,8 @@ class FileProcessor:
         """
         input_paths = []
         for path_raw in self.input:
-            path = glob.glob(str(path_raw), recursive=True)
-            input_paths += path
+            paths = glob.glob(str(path_raw), recursive=True)
+            input_paths += paths
         self.input = list(map(Path, input_paths))
         return self
 

--- a/gribmagic/util.py
+++ b/gribmagic/util.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from dateutil.parser import parse
 
+logger = logging.getLogger(__name__)
+
 
 def setup_logging(level=logging.INFO) -> None:
     log_format = "%(asctime)-15s [%(name)-30s] %(levelname)-7s: %(message)s"
@@ -67,3 +69,9 @@ def load_module(name: str, path: str):
     os.chdir(current_dir)
 
     return mod
+
+
+def run_command(command):
+    logger.debug(f"Running command: {command}")
+    exitcode = os.WEXITSTATUS(os.system(command))
+    assert exitcode == 0, exitcode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ markers = [
     "command: Tests invoking the command line interface.",
     "unit: Unit tests FTW.",
     "bbox: Tests related to bounding box extraction.",
+    "regrid: Tests related to regridding.",
 ]

--- a/tests/dwd/recipe_icon_global_temp2m_single.py
+++ b/tests/dwd/recipe_icon_global_temp2m_single.py
@@ -1,0 +1,17 @@
+"""
+Describe an example recipe for acquiring only a single GRIB file,
+for testing purposes.
+
+Because the regridding process is quite expensive, let's limit it
+to be performed on one file only, in order to save resources.
+"""
+from gribmagic.dwd.download import Parameter, Recipe
+
+recipe = Recipe(
+    model="icon",
+    grid="icosahedral",
+    parameters=[
+        Parameter(name="t_2m", level="single-level"),
+    ],
+    parameter_options={"timesteps": range(0, 1)},
+)

--- a/tests/smith/test_bbox_commands.py
+++ b/tests/smith/test_bbox_commands.py
@@ -50,6 +50,7 @@ def test_bbox_basic_success(gm_data_path, capsys):
     assert "plot" in first_item
 
     assert first_item["input"].endswith(".grib2")
+    assert first_item["output"].endswith(".grib2")
     assert "bbox_" in first_item["output"]
     assert first_item["plot"] is None
 

--- a/tests/smith/test_regrid_commands.py
+++ b/tests/smith/test_regrid_commands.py
@@ -1,0 +1,72 @@
+"""
+Invoke the tests in this file using::
+
+    pytest -vvv -m "regrid and command"
+"""
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from gribmagic.commands import cli
+
+
+@pytest.mark.regrid
+@pytest.mark.command
+def test_regrid_basic_success(gm_data_path, capsys):
+    runner = CliRunner()
+
+    # Acquire data.
+    result = runner.invoke(
+        cli,
+        [
+            "dwd",
+            "acquire",
+            "--recipe=tests/dwd/recipe_icon_global_temp2m_single.py",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # Run bbox on data.
+    result = runner.invoke(
+        cli,
+        [
+            "smith",
+            "regrid",
+            f"{gm_data_path}/icon/**/*icon_global_icosahedral*.grib2",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # Sanitize output.
+    output = result.output.replace("-->> Could not load netCDF4! <<--", "")
+
+    # Check results.
+    report = json.loads(output)
+    assert len(report) == 1
+
+    first_item = report[0]
+
+    assert "input" in first_item
+    assert "output" in first_item
+
+    assert first_item["input"].endswith(".grib2")
+    assert first_item["output"].endswith(".grib2")
+    assert "-latlon-long1" in first_item["output"]
+
+
+@pytest.mark.regrid
+@pytest.mark.command
+def test_regrid_basic_input_files_failure(gm_data_path, capsys):
+    runner = CliRunner()
+
+    # Run bbox on data.
+    result = runner.invoke(
+        cli,
+        [
+            "smith",
+            "regrid",
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    assert "Error: Missing argument 'INPUT...'" in result.output

--- a/tests/smith/test_regrid_units.py
+++ b/tests/smith/test_regrid_units.py
@@ -1,0 +1,114 @@
+from pathlib import Path
+from typing import List
+
+import cfgrib
+import pytest
+import xarray as xr
+
+from gribmagic.smith.regrid.engine import GridTransformationLibrary, RegridTransformer
+from gribmagic.smith.regrid.model import GridKind
+from gribmagic.smith.util import ProcessingResult
+from tests.unity.fixtures import (
+    icon_global_icosahedral_input_file,
+    icon_global_icosahedral_regridded_output_filename,
+)
+
+
+@pytest.mark.regrid
+@pytest.mark.unit
+def test_regrid_success(gm_data_path, tmpdir):
+
+    # Check dimensions and grid type of input file.
+    ds_in: xr.Dataset = cfgrib.open_dataset(icon_global_icosahedral_input_file)
+    assert ds_in.dims == {"values": 2949120}
+    assert ds_in.variables["gust"].attrs["GRIB_gridType"] == "unstructured_grid"
+
+    # Load grid transformation asset files.
+    gridlib = GridTransformationLibrary()
+    gridinfo = gridlib.get_info(kind="global", resolution_dw=0.25)
+
+    # Transform grid / regrid.
+    transformer = RegridTransformer(
+        gridinfo=gridinfo, input=[icon_global_icosahedral_input_file], output=tmpdir
+    )
+    transformer.setup()
+    results: List[ProcessingResult] = transformer.process()
+
+    # Check output filename.
+    item = results[0]
+    assert item.output.match(icon_global_icosahedral_regridded_output_filename)
+    assert item.output.exists()
+
+    # Check dimensions and grid type of output file.
+    ds_out: xr.Dataset = cfgrib.open_dataset(item.output)
+    assert ds_out.dims == {"latitude": 721, "longitude": 1440}
+    assert ds_out.variables["gust"].attrs["GRIB_gridType"] == "regular_ll"
+
+    # Check variables.
+    assert "latitude" in ds_out.variables
+    assert "longitude" in ds_out.variables
+    assert "gust" in ds_out.variables
+
+    # Check coordinate ranges.
+    assert min(ds_out.variables["latitude"].data) == -90
+    assert max(ds_out.variables["latitude"].data) == +90
+    assert min(ds_out.variables["longitude"].data) == -180
+    assert max(ds_out.variables["longitude"].data) == 179.75
+
+    # Check parameter values.
+    assert len(ds_out.variables["gust"]) == 721
+
+
+@pytest.mark.regrid
+@pytest.mark.unit
+def test_regrid_dryrun_success(gm_data_path, tmpdir):
+
+    # Check dimensions and grid type of input file.
+    # ds_in: xr.Dataset = cfgrib.open_dataset(icon_global_icosahedral_input_file)
+    # assert ds_in.dims == {"values": 2949120}
+    # assert ds_in.variables["gust"].attrs["GRIB_gridType"] == "unstructured_grid"
+
+    # Load grid transformation asset files.
+    gridlib = GridTransformationLibrary()
+    gridinfo = gridlib.get_info(kind="global", resolution_dw=0.25)
+
+    # Transform grid / regrid.
+    transformer = RegridTransformer(
+        gridinfo=gridinfo, input=[icon_global_icosahedral_input_file], output=tmpdir, dry_run=True
+    )
+    # transformer.setup()
+    results: List[ProcessingResult] = transformer.process()
+
+    # Check output filename.
+    item = results[0]
+    assert item.output.match(icon_global_icosahedral_regridded_output_filename)
+    assert not item.output.exists()
+
+
+def test_kind_from_model():
+
+    gtl = GridTransformationLibrary()
+
+    kind = gtl.kind_from_model(model="GLOBAL", resolution=0.125)
+    assert kind == GridKind.ICON_GLOBAL2WORLD_0125
+
+    kind = gtl.kind_from_model(model="GLOBAL", resolution=0.250)
+    assert kind == GridKind.ICON_GLOBAL2WORLD_025
+
+    kind = gtl.kind_from_model(model="EU", resolution=0.125)
+    assert kind == GridKind.ICON_GLOBAL2EUAU_0125
+
+    kind = gtl.kind_from_model(model="EU", resolution=0.250)
+    assert kind == GridKind.ICON_GLOBAL2EUAU_025
+
+    with pytest.raises(ValueError) as ex:
+        gtl.kind_from_model(model="global", resolution=0.123)
+    assert ex.match("Unknown grid resolution requested")
+
+    with pytest.raises(ValueError) as ex:
+        gtl.kind_from_model(model="eu", resolution=0.123)
+    assert ex.match("Unknown grid resolution requested")
+
+    with pytest.raises(ValueError) as ex:
+        gtl.kind_from_model(model="foobar", resolution=0.123)
+    assert ex.match("Unknown grid kind requested")

--- a/tests/unity/fixtures.py
+++ b/tests/unity/fixtures.py
@@ -24,8 +24,16 @@ recipe_harmonie = AcquisitionRecipe(
 
 testdata_path = Path(f"{os.getcwd()}/.gribmagic-testdata")
 
-icon_global_input_file = (
+icon_global_latlon_input_file = (
     testdata_path / "input" / "icon-global_regular-lat-lon_air-temperature_level-90.grib2"
+)
+
+icon_global_icosahedral_input_file = (
+    testdata_path / "input" / "icon_global_icosahedral_single-level_2021102018_001_VMAX_10M.grib2"
+)
+
+icon_global_icosahedral_regridded_output_filename = (
+    "icon_global_icosahedral_single-level_2021102018_001_VMAX_10M-latlon-long1.grib2"
 )
 
 icon_eu_input_file = (


### PR DESCRIPTION
Hi there,

this patch adds the `gribmagic.smith.regrid` module and the accompanying command `gribmagic smith regrid`. It has code to transform DWD ICON's `icosahedral`-gridded files into regular grids in `long1` format.

With kind regards,
Andreas.
