### PR TITLE
CI: Parallelize test execution using `pytest-xdist`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
         sudo apt-get install --yes libeccodes0 cdo libmagplus3v5
 
     - name: Run tests, with coverage
-      run: make test-coverage
+      run: make test-coverage-parallel
 
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ GribMagic changelog
 
 in progress
 ===========
-- CI: Parallelize test execution using `pytest-xdist`
+- CI: Parallelize test execution using ``pytest-xdist``
+- Fix day turnover computation in ``previous_modelrun()``
 
 
 2021-10-24 0.2.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ GribMagic changelog
 
 in progress
 ===========
+- CI: Parallelize test execution using `pytest-xdist`
 
 
 2021-10-24 0.2.0

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ test: install-tests
 	@echo "==================="
 	@echo "Invoking test suite"
 	@echo "==================="
-	@$(pytest) -vvv tests
+	@$(pytest) -vvv tests ${ARGS}
+
+test-parallel:
+	@$(MAKE) test ARGS=--numprocesses=auto
 
 test-refresh: install-tests test
 
@@ -48,7 +51,11 @@ test-coverage: install-tests
 		--cov-report=term-missing \
 		--cov-report=html:.pytest_results/htmlcov \
 		--cov-report=xml:.pytest_results/coverage.xml \
-		--junit-xml=.pytest_results/pytest.xml
+		--junit-xml=.pytest_results/pytest.xml \
+		${ARGS}
+
+test-coverage-parallel:
+	@$(MAKE) test-coverage ARGS=--numprocesses=auto
 
 
 # ----------------------

--- a/docs/backlog.rst
+++ b/docs/backlog.rst
@@ -56,7 +56,14 @@ Prio 2
 - [o] Implement ``gribmagic/unity/modules/parsing/unify_data.py``
 - [o] What about https://opendata.dwd.de/weather/lib/grib/eccodes_definitions.edzw-2.22.1-1.tar.bz2 ?
 - [o] Elevation data from https://github.com/bopen/elevation?
+- [o] https://github.com/prayer007/dwdGribExtractor
 
+- [o] ICON-D2:
+        '''Gets the number of the current run by current time.
+        The latest run is fully available ~2h after initialisation.
+        e.g. The 09 run will be finished at approx 11:00 UTC.
+
+  -- https://github.com/prayer007/dwdGribExtractor/blob/be1481e968123a04d5700016fe6a2fa4259b6048/dwdGribExtractor/icon.py#L94-L96
 
 ******
 Prio 3

--- a/gribmagic/smith/regrid/cli.py
+++ b/gribmagic/smith/regrid/cli.py
@@ -25,9 +25,9 @@ from gribmagic.util import setup_logging
 @click.option(
     "--resolution",
     type=float,
-    help="Which resolution to select. Use `0.125` or `0.25`",
+    help="Which resolution to select. Use `0.125` or `0.250`",
     required=False,
-    default=0.25,
+    default=0.250,
 )
 @click.option(
     "--dry-run", is_flag=True, help="Whether to simulate processing", required=False, default=False

--- a/gribmagic/unity/download/engine.py
+++ b/gribmagic/unity/download/engine.py
@@ -87,7 +87,7 @@ def __download(item: DownloadItem) -> None:
 
     # Compute source URL and target file.
     url = item.remote_url
-    target_file = item.local_file
+    target_file = Path(item.local_file)
 
     if target_file.exists():
         logger.info(f"Skipping existing file {target_file}")

--- a/gribmagic/unity/reader.py
+++ b/gribmagic/unity/reader.py
@@ -72,18 +72,18 @@ def open_grib_file(file_path: Path) -> List[xarray.Dataset]:
 
 
 def create_inventory(
-    dataset: List[xarray.Dataset],
+    datasets: List[xarray.Dataset],
 ) -> Dict[Hashable, List[Union[Dict[str, Union[int, any]], Dict[str, Union[str, int]]]]]:
     """
     Create a dictionary mapping GRIB variables to level_type and index in the list.
     Args:
-        dataset:
+        datasets:
 
     Returns:
         Dict with Level und Index information
     """
     variables_inventory = {}
-    for idx, dat in enumerate(dataset):
+    for idx, dat in enumerate(datasets):
         for item in dat.variables.items():
             varname, xelement = item
             if varname not in NOT_RELEVANT_ATTRIBUTES:

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(name='gribmagic',
         "test": [
           "pytest>=6,<7",
           "pytest-cov>=2.10,<3",
+          "pytest-xdist>=2.4,<3",
           "mock>=4,<5",
           "responses>=0.12,<1",
         ],

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(name='gribmagic',
           "pytest-xdist>=2.4,<3",
           "mock>=4,<5",
           "responses>=0.12,<1",
+          "freezegun>=1.1,<2",
         ],
         "plotting": [
           # We need this version to be compatible with Magics 4.2.6, which is available

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -11,3 +12,8 @@ if "GM_DATA_PATH" in os.environ:
 def gm_data_path(tmpdir):
     with mock.patch.dict("os.environ", {"GM_DATA_PATH": str(tmpdir)}):
         yield tmpdir
+
+
+@pytest.fixture
+def tmpgribfile(tmpdir):
+    yield Path(tmpdir / "test.grib2")

--- a/tests/dwd/test_util.py
+++ b/tests/dwd/test_util.py
@@ -1,0 +1,18 @@
+from freezegun import freeze_time
+
+from tests.dwd.util import previous_modelrun
+
+
+@freeze_time("2012-01-14T18:21:34Z")
+def test_previous_modelrun_standard():
+    assert previous_modelrun() == "2012011412"
+
+
+@freeze_time("2012-01-14T02:00:00Z")
+def test_previous_modelrun_day_before_turnover():
+    assert previous_modelrun() == "2012011318"
+
+
+@freeze_time("2012-01-14T03:00:00Z")
+def test_previous_modelrun_day_after_turnover():
+    assert previous_modelrun() == "2012011400"

--- a/tests/dwd/util.py
+++ b/tests/dwd/util.py
@@ -14,8 +14,12 @@ def nearest_multiple(number, base=10):
 
 def previous_modelrun():
     timestamp = datetime.utcnow() - timedelta(hours=6)
+    day = timestamp.day
     hour = nearest_multiple(timestamp.hour, base=6)
-    timestamp = timestamp.replace(hour=hour, minute=0, second=0, microsecond=0)
+    if hour == 24:
+        day += 1
+        hour = 0
+    timestamp = timestamp.replace(day=day, hour=hour, minute=0, second=0, microsecond=0)
     modelrun = timestamp.strftime("%Y%m%d%H")
     return modelrun
 

--- a/tests/smith/test_regrid_units.py
+++ b/tests/smith/test_regrid_units.py
@@ -1,4 +1,8 @@
-from pathlib import Path
+"""
+Invoke the tests in this file using::
+
+    pytest -vvv -m "regrid and unit"
+"""
 from typing import List
 
 import cfgrib
@@ -25,7 +29,7 @@ def test_regrid_success(gm_data_path, tmpdir):
 
     # Load grid transformation asset files.
     gridlib = GridTransformationLibrary()
-    gridinfo = gridlib.get_info(kind="global", resolution_dw=0.25)
+    gridinfo = gridlib.get_info(kind="global", resolution_dw=0.250)
 
     # Transform grid / regrid.
     transformer = RegridTransformer(
@@ -63,20 +67,14 @@ def test_regrid_success(gm_data_path, tmpdir):
 @pytest.mark.unit
 def test_regrid_dryrun_success(gm_data_path, tmpdir):
 
-    # Check dimensions and grid type of input file.
-    # ds_in: xr.Dataset = cfgrib.open_dataset(icon_global_icosahedral_input_file)
-    # assert ds_in.dims == {"values": 2949120}
-    # assert ds_in.variables["gust"].attrs["GRIB_gridType"] == "unstructured_grid"
-
     # Load grid transformation asset files.
     gridlib = GridTransformationLibrary()
-    gridinfo = gridlib.get_info(kind="global", resolution_dw=0.25)
+    gridinfo = gridlib.get_info(kind="global", resolution_dw=0.250)
 
     # Transform grid / regrid.
     transformer = RegridTransformer(
         gridinfo=gridinfo, input=[icon_global_icosahedral_input_file], output=tmpdir, dry_run=True
     )
-    # transformer.setup()
     results: List[ProcessingResult] = transformer.process()
 
     # Check output filename.
@@ -85,6 +83,8 @@ def test_regrid_dryrun_success(gm_data_path, tmpdir):
     assert not item.output.exists()
 
 
+@pytest.mark.regrid
+@pytest.mark.unit
 def test_kind_from_model():
 
     gtl = GridTransformationLibrary()

--- a/tests/unity/download/test_local_store.py
+++ b/tests/unity/download/test_local_store.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 from io import BytesIO
 
@@ -7,25 +6,17 @@ from gribmagic.unity.download.decoder import (
     decode_identity,
     decode_tarfile,
 )
-from tests.unity.fixtures import (
-    harmonie_input_file,
-    harmonie_output_file,
-    icon_eu_input_file,
-    testdata_path,
-)
-
-output_file = testdata_path / "output/test.grib2"
+from tests.unity.fixtures import harmonie_input_file, icon_eu_input_file
 
 
-def test_bunzip_store():
+def test_bunzip_store(tmpgribfile):
     with open(icon_eu_input_file, "rb") as file:
         test_data = file.read()
-    decode_bunzip(BytesIO(test_data), output_file)
-    assert output_file.is_file() == True
-    os.remove(output_file)
+    decode_bunzip(BytesIO(test_data), tmpgribfile)
+    assert tmpgribfile.is_file() is True
 
 
-def test_identity_store():
+def test_identity_store(tmpgribfile):
 
     tmpfile = tempfile.NamedTemporaryFile()
     tmpfile.write(b"-" * 42)
@@ -33,15 +24,13 @@ def test_identity_store():
 
     with open(tmpfile.name, "rb") as file:
         test_data = file.read()
-    decode_identity(BytesIO(test_data), output_file)
-    assert output_file.is_file() == True
-    os.remove(output_file)
+    decode_identity(BytesIO(test_data), tmpgribfile)
+    assert tmpgribfile.is_file() is True
 
 
-def test_tarfile_store():
+def test_tarfile_store(tmpgribfile):
     with open(harmonie_input_file, "rb") as file:
         test_data = file.read()
 
-    decode_tarfile(BytesIO(test_data), [harmonie_output_file])
-    assert harmonie_output_file.is_file() == True
-    os.remove(harmonie_output_file)
+    decode_tarfile(BytesIO(test_data), [tmpgribfile])
+    assert tmpgribfile.is_file() is True

--- a/tests/unity/test_reader.py
+++ b/tests/unity/test_reader.py
@@ -1,4 +1,3 @@
-import os
 from io import BytesIO
 
 import numpy as np
@@ -35,13 +34,11 @@ def test_concatenate_all_variable_files():
     assert dataset.time.values == np.datetime64("2020-06-23T00:00:00.000000000")
     assert dataset.step.values == np.timedelta64(0)
 
-    os.remove(icon_eu_output_file)
 
+def test_open_grib_file_one_variable(tmpgribfile):
 
-def test_open_grib_file_one_variable():
-
-    decode_bunzip(BytesIO(test_data), icon_eu_output_file)
-    dataset = open_grib_file(icon_eu_output_file)[0]
+    decode_bunzip(BytesIO(test_data), tmpgribfile)
+    dataset = open_grib_file(tmpgribfile)[0]
 
     assert dataset.latitude.shape == (657,)
     assert dataset.longitude.shape == (1097,)
@@ -50,14 +47,12 @@ def test_open_grib_file_one_variable():
     assert dataset.step.values == np.timedelta64(0)
 
 
-def test_create_inventory():
+def test_create_inventory(tmpgribfile):
 
-    decode_bunzip(BytesIO(test_data), icon_eu_output_file)
-    dataset = open_grib_file(icon_eu_output_file)
-    variables_inventory = create_inventory(dataset)
+    decode_bunzip(BytesIO(test_data), tmpgribfile)
+    datasets = open_grib_file(tmpgribfile)
+    variables_inventory = create_inventory(datasets)
 
     assert variables_inventory == {
         "t2m": [{KEY_LIST_INDEX: 0, KEY_LEVEL_TYPE: "heightAboveGround"}]
     }
-
-    os.remove(icon_eu_output_file)


### PR DESCRIPTION
Running tests in parallel will make the overall process complete earlier, that's the idea. On my workstation, the execution time goes down from ~32s to ~18s, [1] vs. [2].

On CI (which needs to setup a full sandbox each time), the execution time goes down from ~5.5 minutes to ~2.75 minutes.

[1] `time make test-coverage`
[2] `time make test-coverage-parallel`
